### PR TITLE
Bump audrey version in examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/nannou-org/nannou"
 edition = "2018"
 
 [dev-dependencies]
-audrey = "0.2"
+audrey = "0.3"
 futures = "0.3"
 hotglsl = { git = "https://github.com/nannou-org/hotglsl", branch = "master" }
 hrtf = "0.2"


### PR DESCRIPTION
Doesn't compile when audrey version is 0.2